### PR TITLE
fix: Refresh Token 전송 및 쿠키 설정 개선

### DIFF
--- a/ziczone/src/main/java/org/zerock/ziczone/config/CorsConfig.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/config/CorsConfig.java
@@ -1,19 +1,19 @@
-package org.zerock.ziczone.config;
-
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-@Configuration
-public class CorsConfig implements WebMvcConfigurer {
-
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000") // 허용할 출처
-                .allowedMethods("*")
-                .allowedHeaders("*")
-                .allowCredentials(true);
-    }
-}
+//package org.zerock.ziczone.config;
+//
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.web.servlet.config.annotation.CorsRegistry;
+//import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+//
+//@Configuration
+//public class CorsConfig implements WebMvcConfigurer {
+//
+//    @Override
+//    public void addCorsMappings(CorsRegistry registry) {
+//        registry.addMapping("/**")
+//                .allowedOrigins("http://localhost:3000") // 허용할 출처
+//                .allowedMethods("*")
+//                .allowedHeaders("*")
+//                .allowCredentials(true);
+//    }
+//}

--- a/ziczone/src/main/java/org/zerock/ziczone/controller/TokenController.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/controller/TokenController.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.token.TokenService;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.zerock.ziczone.dto.token.RefreshTokenRequestDTO;
 import org.zerock.ziczone.security.JwtService;
 
@@ -21,16 +18,16 @@ public class TokenController {
     private final JwtService jwtService;
 
     @PostMapping("/refresh")
-    public ResponseEntity<?> refreshToken(@RequestBody RefreshTokenRequestDTO refreshTokenRequestDTO) {
-        log.info("Refresh token request received: {}", refreshTokenRequestDTO);
+    public ResponseEntity<?> refreshToken(@RequestBody RefreshTokenRequestDTO refreshTokenRequestDTO,
+                                          @CookieValue(value = "refresh_token", required = false) String refreshToken) {
 
-        if (refreshTokenRequestDTO.getAccessToken() == null || refreshTokenRequestDTO.getRefreshToken() == null) {
+        if (refreshTokenRequestDTO.getAccessToken() == null || refreshToken == null) {
             log.warn("Access token or refresh token is missing");
             return ResponseEntity.badRequest().body(Map.of("message", "Access token and refresh token are required"));
         }
 
         try {
-            String newAccessToken = jwtService.refreshAccessToken(refreshTokenRequestDTO.getAccessToken(), refreshTokenRequestDTO.getRefreshToken());
+            String newAccessToken = jwtService.refreshAccessToken(refreshTokenRequestDTO.getAccessToken(), refreshToken);
             log.info("New access token generated successfully");
             return ResponseEntity.ok(Map.of("access_token", newAccessToken));
         } catch (IllegalArgumentException e) {

--- a/ziczone/src/main/java/org/zerock/ziczone/dto/token/RefreshTokenRequestDTO.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/dto/token/RefreshTokenRequestDTO.java
@@ -11,5 +11,4 @@ import lombok.NoArgsConstructor;
 @Builder
 public class RefreshTokenRequestDTO {
     private String accessToken;
-    private String refreshToken;
 }

--- a/ziczone/src/main/java/org/zerock/ziczone/security/JwtService.java
+++ b/ziczone/src/main/java/org/zerock/ziczone/security/JwtService.java
@@ -33,8 +33,8 @@ public class JwtService {
     private final UserRepository userRepository;
 
     // 토큰의 유효기간
-    static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14; // 14일
-//    static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 30; // 14일
+    static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
+//    static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 30; // 30초
     static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
 //    static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 15; // 임시(15초)
     static final String PREFIX = "Bearer "; // 토큰을 빨리 찾기 위해 붙여주는 문자열


### PR DESCRIPTION
- CORS 설정을 SecurityConfig에서 일괄 관리하도록 변경
- Refresh Token을 HttpOnly 쿠키로 전송하는 로직 추가
- Token 재발급 시 Cookie에서 Refresh Token을 가져오는 로직 추가
* 배포시에는 HTTPS에서만 쿠키를 받을 수 있음